### PR TITLE
resolving lire morph bugs

### DIFF
--- a/src/features/lireMorph/components/LireMorph.tsx
+++ b/src/features/lireMorph/components/LireMorph.tsx
@@ -1,10 +1,10 @@
-import "../layout/lireMorphStyle.css";
-import useLireMorph from "../hooks/useLireMorph";
-import LireoMorthInstructions from "./LireoMorthInstructions";
-import LireoMorphSelector from "./LireoMorphSelector";
-import LireoMorphWordGame from "./LireoMorphWordGame";
-import LireoMorphAffixFilters from "./LireoMorphAffixFilters";
-import LireoMorphMode from "./LireoMorphMode";
+import '../layout/lireMorphStyle.css';
+import useLireMorph from '../hooks/useLireMorph';
+import LireoMorthInstructions from './LireoMorthInstructions';
+import LireoMorphSelector from './LireoMorphSelector';
+import LireoMorphWordGame from './LireoMorphWordGame';
+import LireoMorphAffixFilters from './LireoMorphAffixFilters';
+import LireoMorphMode from './LireoMorphMode';
 
 const LireMorph = () => {
   const {
@@ -44,7 +44,7 @@ const LireMorph = () => {
             chosenMode={chosenMode}
             isMorphemicWord={isMorphemicWord}
           />
-          {chosenMode === "radical" && (
+          {chosenMode === 'radical' && (
             <LireoMorphAffixFilters
               showPrefixes={showPrefixes}
               showSuffixes={showSuffixes}

--- a/src/features/lireMorph/components/LireoMorphMode.tsx
+++ b/src/features/lireMorph/components/LireoMorphMode.tsx
@@ -1,4 +1,4 @@
-import { lireMorphText } from "../texts/lireMorphText";
+import { lireMorphText } from '../texts/lireMorphText';
 
 interface LireoMorphModeProps {
   chosenMode: string | null;
@@ -13,7 +13,7 @@ const LireoMorphMode = ({ chosenMode, selectedMode }: LireoMorphModeProps) => {
           <label
             key={index}
             className={`checkboxLabel modeLabel ${
-              chosenMode === mode ? "selected" : ""
+              chosenMode === mode ? 'selected' : ''
             }`}
           >
             <input

--- a/src/features/lireMorph/hooks/useLireMorph.ts
+++ b/src/features/lireMorph/hooks/useLireMorph.ts
@@ -1,7 +1,7 @@
-import { useState } from "react";
-import useLireMorphFilters from "./useLireMorphFilters";
-import useLireMorphMove from "./useLireMorphMove";
-import useLireMorphData from "./useLireMorphData";
+import { useEffect, useState } from 'react';
+import useLireMorphFilters from './useLireMorphFilters';
+import useLireMorphMove from './useLireMorphMove';
+import useLireMorphData from './useLireMorphData';
 
 const useLireMorph = () => {
   const [summaryClose, setSummaryClose] = useState<boolean>(false);
@@ -31,6 +31,7 @@ const useLireMorph = () => {
     fittedMorph,
     grabMorph,
     setFittedMorph,
+    resetAllDragState,
   } = useLireMorphMove({ setMorphs });
 
   const { showPrefixes, showSuffixes, togglePrefixes, toggleSuffixes } =
@@ -45,6 +46,10 @@ const useLireMorph = () => {
       setMorphs,
       setFittedMorph,
     });
+
+  useEffect(() => {
+    resetAllDragState();
+  }, [chosenMode, selectedMainMorph]);
 
   return {
     summaryClose,

--- a/src/features/lireMorph/hooks/useLireMorphData.ts
+++ b/src/features/lireMorph/hooks/useLireMorphData.ts
@@ -1,13 +1,13 @@
-import { useEffect, useMemo, useState } from "react";
-import { prefixes } from "../texts/prefixes";
-import { radicals } from "../texts/radicals";
-import { suffixes } from "../texts/suffixes";
-import { MorphemicWord } from "../types/morphemicWord.type";
-import { AffixCombination } from "../types/affixCombination.type";
-import { lireMorphText } from "../texts/lireMorphText";
-import { Morph } from "../types/morph.type";
-import { ModeEnum } from "../types/mode.enum";
-import { Position } from "../types/position.type";
+import { useEffect, useMemo, useState } from 'react';
+import { prefixes } from '../texts/prefixes';
+import { radicals } from '../texts/radicals';
+import { suffixes } from '../texts/suffixes';
+import { MorphemicWord } from '../types/morphemicWord.type';
+import { AffixCombination } from '../types/affixCombination.type';
+import { lireMorphText } from '../texts/lireMorphText';
+import { Morph } from '../types/morph.type';
+import { ModeEnum } from '../types/mode.enum';
+import { Position } from '../types/position.type';
 
 interface useLireMorphDataProps {
   setSummaryClose: React.Dispatch<React.SetStateAction<boolean>>;
@@ -20,10 +20,10 @@ const FLUTTER = 5;
 const useLireMorphData = ({ setSummaryClose }: useLireMorphDataProps) => {
   const [morphs, setMorphs] = useState<Morph[]>([]);
   const [selectedMorphIndex, setSelectedMorphIndex] = useState<number | null>(
-    null
+    null,
   );
   const [example, setExample] = useState<MorphemicWord | AffixCombination>(
-    lireMorphText.radicalExample
+    lireMorphText.radicalExample,
   );
   const [morphema, setMorphema] = useState<
     MorphemicWord[] | AffixCombination[]
@@ -56,9 +56,9 @@ const useLireMorphData = ({ setSummaryClose }: useLireMorphDataProps) => {
   };
 
   const isMorphemicWord = (
-    item: MorphemicWord | AffixCombination
+    item: MorphemicWord | AffixCombination,
   ): item is MorphemicWord => {
-    return "radical" in item;
+    return 'radical' in item;
   };
 
   const initializeMorphs = (morphs: string[]): Morph[] => {
@@ -89,8 +89,8 @@ const useLireMorphData = ({ setSummaryClose }: useLireMorphDataProps) => {
             [
               ...(lireMorphText.radicalExample.prefixes || []),
               ...(lireMorphText.radicalExample.suffixes || []),
-            ].map(String)
-          )
+            ].map(String),
+          ),
         );
         break;
       case ModeEnum.SUFFIX:

--- a/src/features/lireMorph/hooks/useLireMorphMove.ts
+++ b/src/features/lireMorph/hooks/useLireMorphMove.ts
@@ -1,6 +1,6 @@
-import { useRef, useState } from "react";
-import { Position } from "../types/position.type";
-import { Morph } from "../types/morph.type";
+import { useRef, useState } from 'react';
+import { Position } from '../types/position.type';
+import { Morph } from '../types/morph.type';
 
 interface useLireMorphMoveProps {
   setMorphs: React.Dispatch<React.SetStateAction<Morph[]>>;
@@ -11,7 +11,7 @@ const DISTANCE_FIT = 15;
 
 const useLireMorphMove = ({ setMorphs }: useLireMorphMoveProps) => {
   const [fittedMorph, setFittedMorph] = useState<{
-    [key: number]: "left" | "right" | null;
+    [key: number]: 'left' | 'right' | null;
   }>({});
   const containerRect = useRef<DOMRect | null>(null);
   const targetMorphRect = useRef<DOMRect | null>(null);
@@ -38,8 +38,8 @@ const useLireMorphMove = ({ setMorphs }: useLireMorphMoveProps) => {
 
     dragState.current.offset = newPosition;
 
-    document.addEventListener("mousemove", moveMorph);
-    document.addEventListener("mouseup", dropMorph);
+    document.addEventListener('mousemove', moveMorph);
+    document.addEventListener('mouseup', dropMorph);
   };
 
   const _resetDragStateToIsDragging = (index: number) => {
@@ -47,6 +47,15 @@ const useLireMorphMove = ({ setMorphs }: useLireMorphMoveProps) => {
     dragState.current.isDragging = true;
     dragState.current.isFittedLeft = false;
     dragState.current.isFittedRight = false;
+  };
+
+  const resetAllDragState = () => {
+    dragState.current.currentIndex = null;
+    dragState.current.isDragging = false;
+    dragState.current.isFittedLeft = false;
+    dragState.current.isFittedRight = false;
+    dragState.current.offset = { x: 0, y: 0 };
+    setFittedMorph({});
   };
 
   const _setTheTargetMorphWithTheMouseInfo = (e: React.MouseEvent) => {
@@ -100,14 +109,14 @@ const useLireMorphMove = ({ setMorphs }: useLireMorphMoveProps) => {
 
   const _newPosition = (
     e: MouseEvent,
-    containerRect: React.RefObject<DOMRect | null>
+    containerRect: React.RefObject<DOMRect | null>,
   ): Position => {
     const leftPercent = _clamp(
       ((e.clientX - containerRect.current!.left - dragState.current.offset.x) /
         containerRect.current!.width) *
         100,
       PADDING,
-      100 - PADDING
+      100 - PADDING,
     );
 
     const topPercent = _clamp(
@@ -115,7 +124,7 @@ const useLireMorphMove = ({ setMorphs }: useLireMorphMoveProps) => {
         containerRect.current!.height) *
         100,
       PADDING,
-      100 - PADDING
+      100 - PADDING,
     );
 
     return { x: leftPercent, y: topPercent };
@@ -127,8 +136,8 @@ const useLireMorphMove = ({ setMorphs }: useLireMorphMoveProps) => {
   const dropMorph = () => {
     fitWithRadical();
     dragState.current.isDragging = false;
-    document.removeEventListener("mousemove", moveMorph);
-    document.removeEventListener("mouseup", dropMorph);
+    document.removeEventListener('mousemove', moveMorph);
+    document.removeEventListener('mouseup', dropMorph);
   };
 
   const _verifyIfTheLeftOrRightIsOccupied = () => {
@@ -136,10 +145,10 @@ const useLireMorphMove = ({ setMorphs }: useLireMorphMoveProps) => {
     if (currentIndex === null)
       return { isLeftOccupied: false, isRightOccupied: false };
     const isLeftOccupied = Object.entries(fittedMorph).some(
-      ([idx, side]) => parseInt(idx) !== currentIndex && side === "left"
+      ([idx, side]) => parseInt(idx) !== currentIndex && side === 'left',
     );
     const isRightOccupied = Object.entries(fittedMorph).some(
-      ([idx, side]) => parseInt(idx) !== currentIndex && side === "right"
+      ([idx, side]) => parseInt(idx) !== currentIndex && side === 'right',
     );
     return {
       isLeftOccupied,
@@ -162,16 +171,16 @@ const useLireMorphMove = ({ setMorphs }: useLireMorphMoveProps) => {
     const radicalRect = mainMorphRef.current.getBoundingClientRect();
 
     const distanceLeft = Math.abs(
-      targetMorphRect.current.right - radicalRect.left
+      targetMorphRect.current.right - radicalRect.left,
     );
     const distanceRight = Math.abs(
-      targetMorphRect.current.left - radicalRect.right
+      targetMorphRect.current.left - radicalRect.right,
     );
     const distanceTop = targetMorphRect.current.bottom - radicalRect.top;
     const distanceBottom = targetMorphRect.current.top - radicalRect.bottom;
 
     let fitPosition: Position = { x: 0, y: 0 };
-    let fittedSide: "left" | "right" | null = null;
+    let fittedSide: 'left' | 'right' | null = null;
 
     if (distanceBottom < THRESHOLD || distanceTop < THRESHOLD) {
       fitPosition.y =
@@ -187,7 +196,7 @@ const useLireMorphMove = ({ setMorphs }: useLireMorphMoveProps) => {
 
     if (distanceLeft < THRESHOLD && !isLeftOccupied) {
       dragState.current.isFittedLeft = true;
-      fittedSide = "left";
+      fittedSide = 'left';
       fitPosition.x =
         ((radicalRect.left -
           targetMorphRect.current.width / 2 -
@@ -197,7 +206,7 @@ const useLireMorphMove = ({ setMorphs }: useLireMorphMoveProps) => {
         100;
     } else if (distanceRight < THRESHOLD && !isRightOccupied) {
       dragState.current.isFittedRight = true;
-      fittedSide = "right";
+      fittedSide = 'right';
       fitPosition.x =
         ((radicalRect.right -
           containerRect.current.left +
@@ -220,8 +229,8 @@ const useLireMorphMove = ({ setMorphs }: useLireMorphMoveProps) => {
                 ...a,
                 position: fitPosition,
               }
-            : a
-        )
+            : a,
+        ),
       );
     } else {
       dragState.current.isFittedLeft = false;
@@ -245,6 +254,7 @@ const useLireMorphMove = ({ setMorphs }: useLireMorphMoveProps) => {
     fittedMorph,
     grabMorph,
     setFittedMorph,
+    resetAllDragState,
   };
 };
 

--- a/src/features/lireMorph/texts/radicals.ts
+++ b/src/features/lireMorph/texts/radicals.ts
@@ -1,10 +1,10 @@
-import { MorphemicWord } from "../types/morphemicWord.type";
-import { PrefixEnum } from "../types/prefix.enum";
-import { SuffixEnum } from "../types/suffix.enum";
+import { MorphemicWord } from '../types/morphemicWord.type';
+import { PrefixEnum } from '../types/prefix.enum';
+import { SuffixEnum } from '../types/suffix.enum';
 
 export const radicals = <MorphemicWord[]>[
   {
-    radical: "flor",
+    radical: 'flor',
     prefixes: [],
     suffixes: [
       SuffixEnum.IDO,
@@ -14,7 +14,7 @@ export const radicals = <MorphemicWord[]>[
     ],
   },
   {
-    radical: "escr",
+    radical: 'escr',
     prefixes: [],
     suffixes: [
       SuffixEnum.EVER,
@@ -24,57 +24,57 @@ export const radicals = <MorphemicWord[]>[
     ],
   },
   {
-    radical: "pensa",
+    radical: 'pensa',
     prefixes: [],
     suffixes: [SuffixEnum.MENTO, SuffixEnum.DOR],
   },
   {
-    radical: "audi",
+    radical: 'audi',
     prefixes: [],
     suffixes: [SuffixEnum.CAO, SuffixEnum.TORIO, SuffixEnum.TIVEL],
   },
   {
-    radical: "limp",
+    radical: 'limp',
     prefixes: [],
     suffixes: [SuffixEnum.EZA, SuffixEnum.O],
   },
   {
-    radical: "cort",
+    radical: 'cort',
     prefixes: [],
     suffixes: [SuffixEnum.E, SuffixEnum.ANTE],
   },
   {
-    radical: "constru",
+    radical: 'constru',
     prefixes: [],
     suffixes: [SuffixEnum.TOR, SuffixEnum.CAO],
   },
   {
-    radical: "trabalh",
+    radical: 'trabalh',
     prefixes: [],
     suffixes: [SuffixEnum.A, SuffixEnum.ADOR],
   },
   {
-    radical: "viv",
+    radical: 'viv',
     prefixes: [PrefixEnum.RE],
     suffixes: [SuffixEnum.ER, SuffixEnum.A],
   },
   {
-    radical: "cant",
+    radical: 'cant',
     prefixes: [],
     suffixes: [SuffixEnum.ORA, SuffixEnum.ORIA],
   },
   {
-    radical: "pedr",
+    radical: 'pedr',
     prefixes: [],
     suffixes: [SuffixEnum.EIRO, SuffixEnum.EGULHO, SuffixEnum.ARIA],
   },
   {
-    radical: "cafe",
+    radical: 'cafe',
     prefixes: [],
     suffixes: [SuffixEnum.TERIA, SuffixEnum.TEIRA, SuffixEnum.ZAL],
   },
   {
-    radical: "ferr",
+    radical: 'ferr',
     prefixes: [],
     suffixes: [
       SuffixEnum.EIRO,
@@ -84,22 +84,22 @@ export const radicals = <MorphemicWord[]>[
     ],
   },
   {
-    radical: "livr",
+    radical: 'livr',
     prefixes: [],
     suffixes: [SuffixEnum.ARIA, SuffixEnum.EIRO],
   },
   {
-    radical: "mar",
+    radical: 'mar',
     prefixes: [],
     suffixes: [SuffixEnum.INHO, SuffixEnum.ITIMO],
   },
   {
-    radical: "fort",
+    radical: 'fort',
     prefixes: [],
     suffixes: [SuffixEnum.IFICAR, SuffixEnum.ALEZA, SuffixEnum.ISSIMO],
   },
   {
-    radical: "dent",
+    radical: 'dent',
     prefixes: [],
     suffixes: [SuffixEnum.ISTA, SuffixEnum.AL],
   },


### PR DESCRIPTION
## 📝 Description

This update introduces a consistent reset mechanism for the drag-and-drop interaction through the new resetAllDragState function. Previously, the drag state was being reset directly inside event handlers, causing timing issues due to React’s asynchronous state updates. This led to situations where the reset happened before the layout had actually changed, especially when switching modes or selecting a new main morph.

With this improvement, the reset behavior is now handled through a dedicated effect that reacts to chosenMode and selectedMainMorph, ensuring that the drag state resets only after all dependent UI updates are completed. As a result, the interaction becomes more predictable.

## ✅ Checklist

Please make sure you have completed all of the following items before submitting this PR:

- [ x ] My code follows the style guidelines of this project.
- [ x ] I have performed a self-review of my own code.
- [ x ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ x ] I have created a constants file, or added the constants to their proper locations.
- [ x ] I have created a hook to contain non-UI logic.
- [ ] I have performed a pair review.
